### PR TITLE
export definition of vm_exec() to avoid SEGV

### DIFF
--- a/vm_eval.c
+++ b/vm_eval.c
@@ -22,7 +22,13 @@ static inline VALUE vm_yield_with_cref(rb_thread_t *th, int argc, const VALUE *a
 static inline VALUE vm_yield(rb_thread_t *th, int argc, const VALUE *argv);
 static inline VALUE vm_yield_with_block(rb_thread_t *th, int argc, const VALUE *argv, VALUE block_handler);
 static inline VALUE vm_yield_force_blockarg(rb_thread_t *th, VALUE args);
+
+#endif /* #ifndef MJIT_HEADER */
+
 VALUE vm_exec(rb_thread_t *th);
+
+#ifndef MJIT_HEADER
+
 static void vm_set_eval_stack(rb_thread_t * th, const rb_iseq_t *iseq, const rb_cref_t *cref, const struct rb_block *base_block);
 static int vm_collect_local_variables_in_heap(rb_thread_t *th, const VALUE *dfp, const struct local_var_list *vars);
 


### PR DESCRIPTION
This command can causes SEGV:

```
$ make miniruby install-rb-mjit-header && ./miniruby -j:v=1 -j -e 'def foo; bar.to_s; end; def bar; "".dup; end; 100.times do foo; sleep 0.01; end'
```

It is thought to be due to the lack of `vm_exec()` definition.
Works fine with the PRed commit in my docker sandbox, gcc version 5.4.0 20160609 on ubuntu 16.04.