### PR TITLE
BASERUBY might be < 2.4

### DIFF
--- a/tool/minimize_mjit_header.rb
+++ b/tool/minimize_mjit_header.rb
@@ -51,7 +51,7 @@ module MJITHeader
   # Return true if CC with CFLAGS compiles successfully the current code.
   # Use STAGE in the message in case of a compilation failure
   def self.check_code!(code, cc, cflags, stage:)
-    Tempfile.create do |f|
+    Tempfile.create("") do |f|
       f.puts code
       f.close
 


### PR DESCRIPTION
`Tempfile.create` calling without any parameters is a 2.4 feature.
I discovered this when I tried to build yarv-mjit in sandbox ubuntu 16.04 LTS with its ruby2.3 package.

Of course, I can use official ruby-2.4 package or rbenv, but I want to skip BASERUBY building.

refs:
https://github.com/ruby/ruby/blob/v2_4_2/doc/ChangeLog-2.4.0#L1041
https://bugs.ruby-lang.org/issues/11965
