### PR TITLE
improve MJIT compile test

### DIFF
--- a/test/jit/test_compile.rb
+++ b/test/jit/test_compile.rb
@@ -8,7 +8,6 @@ class TestCompile < Test::Unit::TestCase
     nop
     getlocal
     setlocal
-    setblockparam
     getspecial
     setspecial
     getinstancevariable

--- a/test/jit/test_compile.rb
+++ b/test/jit/test_compile.rb
@@ -141,14 +141,14 @@ class TestCompile < Test::Unit::TestCase
     begin;
       iseq = RubyVM::InstructionSequence.compile(<<-'begin;;' + "\\n" + <<-'end;;', nil, nil, 1#{feature_string})
       begin;;
-        #{NUM_CALLS_TO_ADD}.times do
-          unless $0
-            #{code}
-          end
+        unless $0
+          #{code}
         end
       end;;
       STDERR.puts iseq.disasm
-      iseq.eval
+      #{NUM_CALLS_TO_ADD}.times do
+        iseq.eval
+      end
       STDIN.getc
     end;
 


### PR DESCRIPTION
* Remove `setblockparam` because it is not supported yet.
* Make test iseq simpler: move "Integer#times" to out of ISeq.
* Add tests.

I believe each tests should be smaller, but now they depend no small CPU times.
`MJIT.compile(iseq)` would resolve it in the future.