### PR TITLE
Embed cc itself instead of its members

### DIFF
--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -185,7 +185,7 @@ compile_send(FILE *f, const VALUE *operands, unsigned int stack_size, int with_b
 	argc += ((ci->flag & VM_CALL_ARGS_BLOCKARG) ? 1 : 0);
     }
 
-    fprintf(f, "  if (UNLIKELY(mjit_check_invalid_cc(stack[%d], %llu, %llu))) {\n", stack_size - 1 - argc, cc->method_state, cc->class_serial);
+    fprintf(f, "  if (UNLIKELY(mjit_check_invalid_cc(stack[%d], (CALL_CACHE)0x%"PRIxVALUE"))) {\n", stack_size - 1 - argc, cc);
     fprintf(f, "    cfp->sp = cfp->bp + %d;\n", stack_size + 1);
     fprintf(f, "    goto cancel;\n");
     fprintf(f, "  }\n");

--- a/mjit_helper.h
+++ b/mjit_helper.h
@@ -10,9 +10,9 @@
    As inlining whole vm_search_method is too heavy for compiler optimizations,
    we use only this part in JIT-ed code. */
 static inline int
-mjit_check_invalid_cc(VALUE obj, rb_serial_t method_state, rb_serial_t class_serial)
+mjit_check_invalid_cc(VALUE obj, CALL_CACHE cc)
 {
-    return GET_GLOBAL_METHOD_STATE() != method_state || RCLASS_SERIAL(CLASS_OF(obj)) != class_serial;
+    return GET_GLOBAL_METHOD_STATE() != cc->method_state || RCLASS_SERIAL(CLASS_OF(obj)) != cc->class_serial;
 }
 
 static inline VALUE


### PR DESCRIPTION
Following command may cause SEGV.

```
$ ./miniruby -j:v=1 -e 'def foo n; %w[foo bar][n].to_s; end; 5.times {|i| foo i }; sleep 1; 5.times {|i| foo i }'
JIT success (44.4ms): block in <main>@-e:1 -> /tmp/_mjitp15726u0.c
JIT success (69.0ms): foo@-e:1 -> /tmp/_mjitp15726u1.c
-e:1: [BUG] Segmentation fault at 0x0000000000000008
ruby 2.5.0dev (2017-11-06 yarv-mjit/master 60673) [x86_64-linux]

(snip)
```

I confirmed that `cc->class_serial` can be changed by vm_search_method().

```
$ git diff
diff --git a/mjit_compile.c b/mjit_compile.c
index c3f6d1aa11..5059cc3460 100644
--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -185,6 +185,10 @@ compile_send(FILE *f, const VALUE *operands, unsigned int stack_size, int with_b
        argc += ((ci->flag & VM_CALL_ARGS_BLOCKARG) ? 1 : 0);
     }
 
+    fprintf(f, "  {\n");
+    fprintf(f, "    CALL_CACHE cc = (CALL_CACHE) %llu;\n", cc);
+    fprintf(f, "    fprintf(stderr, \"compile_send     %%llu %%llu %%llu\\n\", cc, cc->class_serial, cc->method_state);\n");
+    fprintf(f, "  }\n");
     fprintf(f, "  if (UNLIKELY(mjit_check_invalid_cc(stack[%d], %llu, %llu))) {\n", stack_size - 1 - argc, cc->method_state, cc->class_serial);
     fprintf(f, "    cfp->sp = cfp->bp + %d;\n", stack_size + 1);
     fprintf(f, "    goto cancel;\n");
diff --git a/vm_insnhelper.c b/vm_insnhelper.c
index 30d532d3b7..bee5494052 100644
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1323,6 +1323,7 @@ vm_search_method(const struct rb_call_info *ci, struct rb_call_cache *cc, VALUE
 #if OPT_INLINE_METHOD_CACHE
     cc->method_state = GET_GLOBAL_METHOD_STATE();
     cc->class_serial = RCLASS_SERIAL(klass);
+    fprintf(stderr, "vm_search_method %llu %llu %llu\n", cc, cc->class_serial, cc->method_state);
 #endif
 }
 
$ ./miniruby -j:v=1 -e 'def foo n; %w[foo bar][n].to_s; end; 5.times {|i| foo i }; sleep 1; 5.times {|i| foo i }'
vm_search_method 94534711167360 4609 128
vm_search_method 94534711167400 5177 129
vm_search_method 94534711166416 4384 129
vm_search_method 94534711165384 5115 129
vm_search_method 94534711165384 5109 129
vm_search_method 94534711167440 4384 129
JIT success (43.7ms): block in <main>@-e:1 -> /tmp/_mjitp16730u0.c
JIT success (69.7ms): foo@-e:1 -> /tmp/_mjitp16730u1.c
vm_search_method 94534711167480 5177 129
vm_search_method 94534711167232 4384 129
compile_send     94534711165384 5109 129
vm_search_method 94534711165384 5115 129
compile_send     94534711165384 5115 129
compile_send     94534711165384 5115 129
-e:1: [BUG] Segmentation fault at 0x0000000000000008
ruby 2.5.0dev (2017-11-06 yarv-mjit/master 60673) [x86_64-linux]

(snip)
```