### PR TITLE
Try to use cc->call when inline method can't use

### DIFF
--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -101,27 +101,36 @@ fprint_call_method(FILE *f, VALUE ci_v, VALUE cc_v, unsigned int result_pos)
 {
     const rb_iseq_t *iseq;
     CALL_CACHE cc = (CALL_CACHE)cc_v;
-
-    if (inlinable_cfunc_p(cc)) {
-	fprintf(f, "    stack[%d] = mjit_call_cfunc(ec, cfp, &calling, 0x%"PRIxVALUE", 0x%"PRIxVALUE");\n", result_pos, ci_v, (VALUE)cc->me);
-	return;
-    }
+    int cfunc_p;
 
     fprintf(f, "    {\n");
     fprintf(f, "      VALUE v;\n");
 
+    if (cfunc_p = inlinable_cfunc_p(cc)) {
+	fprintf(f, "      if (LIKELY(inlinable)) {\n");
+	fprintf(f, "        stack[%d] = mjit_call_cfunc(ec, cfp, &calling, 0x%"PRIxVALUE", 0x%"PRIxVALUE");\n", result_pos, ci_v, (VALUE)cc->me);
     /* In the condition that CI_SET_FASTPATH (in vm_callee_setup_arg) is called from vm_call_iseq_setup, this inlines vm_call_iseq_setup_normal */
-    if (iseq = inlinable_iseq((CALL_INFO)ci_v, cc)) {
+    } else if (iseq = inlinable_iseq((CALL_INFO)ci_v, cc)) {
 	/* TODO: check calling->argc for argument_arity_error */
 	int param_size = iseq->body->param.size;
+	fprintf(f, "    if (LIKELY(inlinable)) {\n");
 	fprintf(f, "      VALUE *argv = cfp->sp - calling.argc;\n");
 	fprintf(f, "      cfp->sp = argv - 1;\n"); /* recv */
 	fprintf(f, "      vm_push_frame(ec, 0x%"PRIxVALUE", VM_FRAME_MAGIC_METHOD | VM_ENV_FLAG_LOCAL, calling.recv, "
 		"calling.block_handler, 0x%"PRIxVALUE", 0x%"PRIxVALUE", argv + %d, %d, %d);\n",
 		(VALUE)iseq, (VALUE)cc->me, (VALUE)iseq->body->iseq_encoded, param_size, iseq->body->local_table_size - param_size, iseq->body->stack_max);
 	fprintf(f, "      v = Qundef;\n");
-    } else {
+    }
+
+    if (cfunc_p || iseq) {
+	fprintf(f, "      } else {\n  ");
+    }
 	fprintf(f, "      v = (*((CALL_CACHE)0x%"PRIxVALUE")->call)(ec, cfp, &calling, 0x%"PRIxVALUE", 0x%"PRIxVALUE");\n", cc_v, ci_v, cc_v);
+    if (iseq) {
+	fprintf(f, "      }\n");
+    }
+    if (!cfunc_p) {
+	fprintf(f, "      {\n");
     }
 
     fprintf(f, "      if (v == Qundef && (v = mjit_exec(ec)) == Qundef) {\n"); /* TODO: we need some check to call `mjit_exec` directly (skipping setjmp), but not done yet */
@@ -131,6 +140,7 @@ fprint_call_method(FILE *f, VALUE ci_v, VALUE cc_v, unsigned int result_pos)
     fprintf(f, "        stack[%d] = v;\n", result_pos);
     fprintf(f, "      }\n");
     fprintf(f, "    }\n");
+    fprintf(f, "  }\n");
 }
 
 /* Compile send and opt_send_without_block instructions to `f`, and return stack size change */
@@ -144,15 +154,21 @@ compile_send(FILE *f, const VALUE *operands, unsigned int stack_size, int with_b
 	argc += ((ci->flag & VM_CALL_ARGS_BLOCKARG) ? 1 : 0);
     }
 
+    fprintf(f, "  {\n");
+    fprintf(f, "    struct rb_calling_info calling;\n");
+
     if (inlinable_cfunc_p(cc) || inlinable_iseq(ci, cc)) {
+	fprintf(f, "  int inlinable = 1;\n");
 	fprintf(f, "  if (UNLIKELY(mjit_check_invalid_cc(stack[%d], %llu, %llu))) {\n", stack_size - 1 - argc, cc->method_state, cc->class_serial);
+	fprintf(f, "   if (UNLIKELY(mjit_check_invalid_cc_ptr(stack[%d], %llu))) {\n", stack_size - 1 - argc, cc);
 	fprintf(f, "    cfp->sp = cfp->bp + %d;\n", stack_size + 1);
 	fprintf(f, "    goto cancel;\n");
+	fprintf(f, "   } else {\n");
+	fprintf(f, "    inlinable = 0;\n");
+	fprintf(f, "   }\n");
 	fprintf(f, "  }\n");
     }
 
-    fprintf(f, "  {\n");
-    fprintf(f, "    struct rb_calling_info calling;\n");
     fprint_args(f, argc + 1, stack_size - argc - 1); /* +1 is for recv */
     if (with_block) {
 	fprintf(f, "    vm_caller_setup_arg_block(ec, cfp, &calling, 0x%"PRIxVALUE", 0x%"PRIxVALUE", FALSE);\n", operands[0], operands[2]);

--- a/mjit_helper.h
+++ b/mjit_helper.h
@@ -15,6 +15,12 @@ mjit_check_invalid_cc(VALUE obj, rb_serial_t method_state, rb_serial_t class_ser
     return GET_GLOBAL_METHOD_STATE() != method_state || RCLASS_SERIAL(CLASS_OF(obj)) != class_serial;
 }
 
+static inline int
+mjit_check_invalid_cc_ptr(VALUE obj, CALL_CACHE cc)
+{
+    return GET_GLOBAL_METHOD_STATE() != cc->method_state || RCLASS_SERIAL(CLASS_OF(obj)) != cc->class_serial;
+}
+
 static inline VALUE
 mjit_call_cfunc_with_frame(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb_calling_info *calling, const struct rb_call_info *ci, const rb_callable_method_entry_t *me)
 {


### PR DESCRIPTION
Inline method call can makes slower after method_state changed.
Here is benchmark script and the results without this patch.

```
$ cat a.rb
require "benchmark"

# decrease GC impact
GC.start
GC.disable

n = 30_000_000
Benchmark.bm(40) do |x|
  # training Benchmark#report at first
  $stdout = open(IO::NULL, "w")
  5.times { x.report{} }
  $stdout = STDOUT

  def foo; bar; end
  def bar; end
  def baz; 1.to_i; end
  5.times { foo; baz }
  sleep 5

  x.report("keep method_state, inlinable iseq")  { n.times { foo } }
  x.report("keep method_state, inlinable cfunc") { n.times { baz } }

  def bar; end
  class Integer; alias to_i to_int; end

  x.report("change method_state, inlinable iseq")  { n.times { foo } }
  x.report("change method_state, inlinable cfunc") { n.times { baz } }

  def foo; bar; end
  def bar; end
  def baz; 1.to_i; end
  5.times { foo; baz }

  def bar; end
  class Integer; alias to_i to_int; end

  sleep 1

  x.report("uninlinable iseq")  { n.times { foo } }
  x.report("uninlinable cfunc") { n.times { baz } }
end

$ ruby --disable-gems -j a.rb
                                               user     system      total        real
keep method_state, inlinable iseq          1.222460   0.003920   1.303989 (  1.225997)
keep method_state, inlinable cfunc         1.154294   0.000039   1.199362 (  1.154092)
change method_state, inlinable iseq        1.867169   0.000027   1.940704 (  1.866741)
change method_state, inlinable cfunc       1.796369   0.000014   1.844349 (  1.796191)
uninlinable iseq                           1.175143   0.000013   1.250726 (  1.174686)
uninlinable cfunc                          1.131761   0.000002   1.178017 (  1.131582)
```

YARV-MJIT can use cc->call after refresh cc, I guess.
Here is the benchmark results with this PR patch.

```
$ ruby --disable-gems -j a.rb
                                               user     system      total        real
keep method_state, inlinable iseq          1.167334   0.000000   1.258169 (  1.166816)
keep method_state, inlinable cfunc         1.150026   0.000000   1.202352 (  1.149926)
change method_state, inlinable iseq        1.206124   0.000000   1.294198 (  1.205871)
change method_state, inlinable cfunc       1.226896   0.000000   1.278382 (  1.226833)
uninlinable iseq                           1.236957   0.000000   1.305147 (  1.238759)
uninlinable cfunc                          1.153489   0.000000   1.207947 (  1.155252)
```