### PR TITLE
Mark mjit units in queue

### DIFF
--- a/mjit.c
+++ b/mjit.c
@@ -428,13 +428,13 @@ remove_from_unit_queue(struct rb_mjit_unit *unit)
     }
 }
 
-/* Remove and return the best unit from unit_queue.  The best
+/* Return the best unit from unit_queue.  The best
    is the first high priority unit or the unit whose iseq has the
    biggest number of calls so far.  */
 static struct rb_mjit_unit *
-get_from_unit_queue()
+best_unit_from_unit_queue()
 {
-    struct rb_mjit_unit *unit, *dequeued = NULL;
+    struct rb_mjit_unit *unit, *best = NULL;
 
     if (unit_queue == NULL)
 	return NULL;
@@ -447,12 +447,12 @@ get_from_unit_queue()
 	    continue;
 	}
 
-	if (dequeued == NULL || dequeued->iseq->body->total_calls < unit->iseq->body->total_calls) {
-	    dequeued = unit;
+	if (best == NULL || best->iseq->body->total_calls < unit->iseq->body->total_calls) {
+	    best = unit;
 	}
     }
 
-    return dequeued;
+    return best;
 }
 
 /* XXX_COMMONN_ARGS define the command line arguments of XXX C
@@ -737,7 +737,7 @@ worker()
 	    native_cond_wait(&mjit_worker_wakeup, &mjit_engine_mutex);
 	    verbose(3, "Getting wakeup from client");
 	}
-	unit = get_from_unit_queue();
+	unit = best_unit_from_unit_queue();
 	CRITICAL_SECTION_FINISH(3, "in worker dequeue");
 
 	if (unit) {

--- a/mjit.h
+++ b/mjit.h
@@ -72,6 +72,7 @@ extern void mjit_finish();
 extern void mjit_gc_start_hook();
 extern void mjit_gc_finish_hook();
 extern void mjit_free_iseq(const rb_iseq_t *iseq);
+extern void mjit_mark();
 
 /* A threshold used to add iseq to JIT. */
 #define NUM_CALLS_TO_ADD 5

--- a/vm.c
+++ b/vm.c
@@ -2120,6 +2120,8 @@ rb_vm_mark(void *ptr)
 	rb_vm_trace_mark_event_hooks(&vm->event_hooks);
 
 	rb_gc_mark_values(RUBY_NSIG, vm->trap_list.cmd);
+
+	mjit_mark();
     }
 
     RUBY_MARK_LEAVE("vm");


### PR DESCRIPTION
wish to fix #20 

Of course we can also take another way to avoid #20. This is just one of many approaches.

And benchmark of optcarrot seems to be OK.

```
$ for branch in yarv-mjit/master yarv-mjit/mark-units; do git checkout $branch && make -j4 REVISION_FORCE=PHONY ./.revision.time install-nodoc >/dev/null 2>&1 && (cd ../optcarrot; ruby -v; for i in `seq 1 1 5`; do ruby -j bin/optcarrot --benchmark examples/Lan_Master.nes|sed -ne "s/^fps: \(.*\)/\1/p"; done|ruby -e 'fps_list = []; while gets; fps = $_.to_f; p fps; fps_list << fps; end; p fps_list.sum / fps_list.length'); done
Switched to branch 'yarv-mjit/master'
Your branch is up-to-date with 'k0kubun/yarv-mjit/master'.
ruby 2.5.0dev (2017-12-01 yarv-mjit/master 60964) [x86_64-linux]
last_commit=common.mk: fix @cmp to cmp
45.46302959083232
45.859669777599414
51.86169720803218
55.74713333181491
53.77089426418877
50.54048483449352
Switched to branch 'yarv-mjit/mark-units'
ruby 2.5.0dev (2017-12-01 yarv-mjit/mark.. 60964) [x86_64-linux]
last_commit=mjit.c: fix comment, function name and variable
56.27655549971053
44.06390464700025
56.70451575508195
53.999139685866325
55.74678733879339
53.358180585290484
```