### PR TITLE
Fix opt_case_dispatch

### DIFF
--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -644,6 +644,8 @@ compile_insn(FILE *f, const struct rb_iseq_constant_body *body, const int insn, 
 
 	    fprintf(f, "  switch (vm_case_dispatch(0x%"PRIxVALUE", 0x%"PRIxVALUE", stack[%d])) {\n", operands[0], operands[1], --b->stack_size);
 	    rb_hash_foreach(operands[0], compile_case_dispatch_each, (VALUE)&arg);
+	    fprintf(f, "    case %lu:\n", operands[1]);
+	    fprintf(f, "      goto label_%lu;\n", arg.base_pos + operands[1]);
 	    fprintf(f, "  }\n");
 	}
         break;


### PR DESCRIPTION
(1) JIT may fail if "when" has literal values:
```
$ ./miniruby -j:v=1 -e 'def foo(n); case n; when 0, 1; 2; else 2; end; end; 5.times { foo(0) } ; sleep 1'
MJIT: CC defaults to gcc

JIT success (39.3ms): block in <main>@-e:1 -> /tmp/_mjitp17913u0.c
/tmp/_mjitp17913u1.c: In function ‘_mjit1’:
/tmp/_mjitp17913u1.c:22:5: error: duplicate case value
     case 16:
     ^~~~
compilation terminated due to -Wfatal-errors.
Successful MJIT finish
```

(2) Return value of `vm_case_dispatch()` may be ignored if it is `else_offset`