### PR TITLE
Add MJIT.compile

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -1779,6 +1779,11 @@ iseqw_s_of(VALUE klass, VALUE body)
     return iseq ? iseqw_new(iseq) : Qnil;
 }
 
+VALUE
+rb_iseqw_of(VALUE obj) {
+    return iseqw_s_of(rb_cISeq, obj);
+}
+
 /*
  *  call-seq:
  *     InstructionSequence.disasm(body) -> str

--- a/iseq.h
+++ b/iseq.h
@@ -189,6 +189,7 @@ VALUE rb_iseq_label(const rb_iseq_t *iseq);
 VALUE rb_iseq_base_label(const rb_iseq_t *iseq);
 VALUE rb_iseq_first_lineno(const rb_iseq_t *iseq);
 VALUE rb_iseq_method_name(const rb_iseq_t *iseq);
+VALUE rb_iseqw_of(VALUE obj);
 
 /* proc.c */
 const rb_iseq_t *rb_method_iseq(VALUE body);

--- a/mjit.c
+++ b/mjit.c
@@ -741,7 +741,7 @@ create_unit(const rb_iseq_t *iseq)
     if (unit == NULL)
 	return;
 
-    unit->id = current_unit_num++;
+    unit->id = -1;
     unit->iseq = iseq;
     iseq->body->jit_unit = unit;
 }
@@ -762,6 +762,7 @@ mjit_add_iseq_to_process(const rb_iseq_t *iseq)
 	return;
 
     CRITICAL_SECTION_START(3, "in add_iseq_to_process");
+    unit->id = current_unit_num++;
     add_to_unit_queue(unit);
     /* TODO: Unload some units if it's >= max_cache_size */
     verbose(3, "Sending wakeup signal to workers in mjit_add_iseq_to_process");

--- a/mjit.c
+++ b/mjit.c
@@ -973,13 +973,21 @@ mjit_enable_get(void)
 }
 
 VALUE
-mjit_s_compile(VALUE recv, VALUE iseqw)
+mjit_s_compile(VALUE recv, VALUE obj)
 {
     struct rb_mjit_unit *unit;
     const rb_iseq_t *iseq;
+    VALUE iseqw;
 
     if (!mjit_init_p)
 	return Qnil;
+
+    if (!rb_obj_is_iseq(obj)) {
+	iseqw = rb_iseqw_of(obj);
+    }
+    else {
+	iseqw = obj;
+    }
 
     iseq = rb_iseqw_to_iseq(iseqw);
     CRITICAL_SECTION_START(3, "mjit_s_compile");


### PR DESCRIPTION
I wish to synchronous JIT compile.
example:
```
$ ./miniruby -j -j:v=1 -e 'a = proc { p 1 }; MJIT.compile(a); a.call'
MJIT: CC defaults to gcc
JIT success (34.6ms): block in <main>@-e:1 -> /tmp/_mjitp24014u0.c
1
Successful MJIT finish
```

Now I have a question about the logic of waiting JIT compile.
I've implemented this feature with  `rb_nativethread_cond_t` at first. ( f44f83c )
But I cast about using `rb_thread_schedule()` in busy loop. ( 0036872 )
What should we do?