### PR TITLE
Use EC_JUMP_TAG for "throw" insn

### DIFF
--- a/mjit_compile.c
+++ b/mjit_compile.c
@@ -593,7 +593,8 @@ compile_insn(FILE *f, const struct rb_iseq_constant_body *body, const int insn, 
 	break;
       case BIN(throw):
 	fprintf(f, "  RUBY_VM_CHECK_INTS(ec);\n");
-	fprintf(f, "  THROW_EXCEPTION(vm_throw(ec, cfp, 0x%"PRIxVALUE", stack[%d]));\n", operands[0], --b->stack_size);
+	fprintf(f, "  ec->errinfo = vm_throw(ec, cfp, 0x%"PRIxVALUE", stack[%d]);\n", operands[0], --b->stack_size);
+	fprintf(f, "  EC_JUMP_TAG(ec, ec->tag->state);\n");
 	b->finish_p = TRUE;
 	break;
       case BIN(jump):


### PR DESCRIPTION
The last test of bootstraptest/test_flow.rb is failed with current c66ca80.
Here are extracted script and an execution result.

```
$ cat a.rb
  class Bug6460
    def m1
      m2 {|e|
        return e
      }
    end

    def m2
      begin
        yield :foo
      ensure
        begin
          begin
            yield :foo
          ensure
            Proc.new
            raise ''
          end
        rescue
        end
      end
    end
  end
  Bug6460.new.m1

$ ./miniruby -j:aot=1 a.rb
a.rb:4: [BUG] Segmentation fault at 0x0000000000000008
ruby 2.6.0dev (2017-12-29 feature/merge-.. 61511) [x86_64-linux]

(snip)
```

The patch is based on @k0kubun 's tweet https://twitter.com/k0kubun/status/947000290561048576. Thank you.