### PR TITLE
Sleep 1ms every one loop to wait to replace jit_func

### DIFF
--- a/mjit.c
+++ b/mjit.c
@@ -1000,10 +1000,14 @@ mjit_add_iseq_to_process(const rb_iseq_t *iseq)
 mjit_func_t
 mjit_get_iseq_func(const struct rb_iseq_constant_body *body)
 {
+    struct timeval tv;
+    tv.tv_sec = 0;
+    tv.tv_usec = 1000;
     while ((enum rb_mjit_iseq_func)body->jit_func == NOT_READY_JIT_ISEQ_FUNC) {
 	CRITICAL_SECTION_START(3, "in mjit_get_iseq_func for a client wakeup");
 	rb_native_cond_broadcast(&mjit_worker_wakeup);
 	CRITICAL_SECTION_FINISH(3, "in mjit_get_iseq_func for a client wakeup");
+        rb_thread_wait_for(tv);
     }
     return body->jit_func;
 }


### PR DESCRIPTION
`-j:aot=n` option is great and useful, but its loop is too busy I guess.

```
$ perf stat ./miniruby -j:aot=1 -e '50.times { (eval "proc { }").call } '
 Performance counter stats for './miniruby -j:aot=1 -e 50.times { (eval "proc { }").call } ':

       3068.777523      task-clock (msec)         #    2.084 CPUs utilized          
               954      context-switches          #    0.311 K/sec                  
               112      cpu-migrations            #    0.036 K/sec                  
           249,838      page-faults               #    0.081 M/sec                  
    10,548,164,029      cycles                    #    3.437 GHz                    
    14,729,418,440      instructions              #    1.40  insn per cycle         
     2,919,051,683      branches                  #  951.210 M/sec                  
        28,642,663      branch-misses             #    0.98% of all branches        

       1.472713365 seconds time elapsed
```

The above is the result with current c66ca80c3f865a4b0b0b1618787c5d947e61fad8.
And the following is the result with this patch.

```
$ perf stat ./miniruby -j:aot=1 -e '50.times { (eval "proc { }").call } '

 Performance counter stats for './miniruby -j:aot=1 -e 50.times { (eval "proc { }").call } ':

       1433.717969      task-clock (msec)         #    1.106 CPUs utilized          
             1,891      context-switches          #    0.001 M/sec                  
               247      cpu-migrations            #    0.172 K/sec                  
           250,169      page-faults               #    0.174 M/sec                  
     4,851,056,006      cycles                    #    3.384 GHz                    
     5,792,558,785      instructions              #    1.19  insn per cycle         
     1,157,995,260      branches                  #  807.687 M/sec                  
        28,902,079      branch-misses             #    2.50% of all branches        

       1.296269164 seconds time elapsed
```

There is not much logic about 1000 micro seconds (= 1ms).